### PR TITLE
Add basic HIS scaffolding with API service

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+class AuthController extends Controller
+{
+    public function login(Request $request)
+    {
+        $credentials = $request->only('email', 'password');
+
+        if (! $token = Auth::attempt($credentials)) {
+            return response()->json(['message' => 'Invalid credentials'], 401);
+        }
+
+        return response()->json(['token' => $token]);
+    }
+
+    public function user()
+    {
+        return response()->json(Auth::user());
+    }
+
+    public function logout()
+    {
+        JWTAuth::invalidate(JWTAuth::getToken());
+
+        return response()->json(['message' => 'Logged out successfully']);
+    }
+}

--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AuthController;
+
+// Ensure users table has at least 'email' and 'password' columns for authentication
+// Generate JWT secret with: php artisan jwt:secret
+
+Route::prefix('api')->group(function () {
+    Route::post('login', [AuthController::class, 'login']);
+
+    Route::middleware('jwt.auth')->group(function () {
+        Route::get('user', [AuthController::class, 'user']);
+        Route::post('logout', [AuthController::class, 'logout']);
+    });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,26 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { Routes, Route, Navigate } from 'react-router-dom'
+import { AuthProvider } from './auth/AuthContext'
+import ProtectedRoute from './auth/ProtectedRoute'
+import MainLayout from './layout/MainLayout'
+import Home from './pages/Home'
+import Dashboard from './pages/Dashboard'
+import LoginPage from './pages/LoginPage'
 import './App.css'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+const App = () => {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <AuthProvider>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route element={<ProtectedRoute />}> 
+          <Route element={<MainLayout />}> 
+            <Route index element={<Home />} />
+            <Route path="dashboard" element={<Dashboard />} />
+          </Route>
+        </Route>
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </AuthProvider>
   )
 }
 

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -1,1 +1,37 @@
-isi
+import { createContext, useContext, useState, ReactNode } from 'react'
+
+interface AuthContextType {
+  user: string | null
+  login: (username: string, cb: () => void) => void
+  logout: (cb: () => void) => void
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<string | null>(null)
+
+  const login = (username: string, cb: () => void) => {
+    setUser(username)
+    cb()
+  }
+
+  const logout = (cb: () => void) => {
+    setUser(null)
+    cb()
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}

--- a/src/auth/ProtectedRoute.tsx
+++ b/src/auth/ProtectedRoute.tsx
@@ -1,1 +1,12 @@
-isi
+import { Navigate, Outlet } from 'react-router-dom'
+import { useAuth } from './AuthContext'
+
+const ProtectedRoute = () => {
+  const { user } = useAuth()
+  if (!user) {
+    return <Navigate to="/login" replace />
+  }
+  return <Outlet />
+}
+
+export default ProtectedRoute

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,1 +1,13 @@
-isi
+import { useAuth } from '../auth/AuthContext'
+
+const Header = () => {
+  const { user, logout } = useAuth()
+  return (
+    <header className="header">
+      <h1>Hospital IS</h1>
+      {user && <button onClick={() => logout(() => {})}>Logout</button>}
+    </header>
+  )
+}
+
+export default Header

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,1 +1,20 @@
-isi
+import { NavLink } from 'react-router-dom'
+
+const Sidebar = () => {
+  return (
+    <aside className="sidebar">
+      <nav>
+        <ul>
+          <li>
+            <NavLink to="/">Home</NavLink>
+          </li>
+          <li>
+            <NavLink to="/dashboard">Dashboard</NavLink>
+          </li>
+        </ul>
+      </nav>
+    </aside>
+  )
+}
+
+export default Sidebar

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,1 +1,19 @@
-isi
+import { Outlet } from 'react-router-dom'
+import Header from '../components/Header'
+import Sidebar from '../components/Sidebar'
+
+const MainLayout = () => {
+  return (
+    <div className="main-layout">
+      <Header />
+      <div className="body">
+        <Sidebar />
+        <main className="content">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  )
+}
+
+export default MainLayout

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
 import './index.css'
-import App from './App.jsx'
 
-createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
 )

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,5 @@
+const Dashboard = () => {
+  return <div>Dashboard</div>
+}
+
+export default Dashboard

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,5 @@
+const Home = () => {
+  return <div>Welcome to the Hospital Information System</div>
+}
+
+export default Home

--- a/src/pages/LoginPage.css
+++ b/src/pages/LoginPage.css
@@ -1,0 +1,80 @@
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+.login-page {
+  display: flex;
+  width: 100%;
+  height: 100vh;
+}
+
+.left-panel {
+  flex: 1;
+  background-color: #0d6efd;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.left-panel .illustration {
+  width: 200px;
+  height: 200px;
+  background: #ffffff33;
+}
+
+.right-panel {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f2f2f2;
+}
+
+.login-form {
+  width: 80%;
+  max-width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-group input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.error {
+  color: red;
+  font-size: 0.8rem;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.9rem;
+}
+
+.login-button {
+  padding: 0.5rem;
+  background-color: #0d6efd;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  width: 100%;
+}
+
+.login-button:hover {
+  background-color: #0b5ed7;
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../auth/AuthContext'
+import api from '../services/api'
+import './LoginPage.css'
+
+interface FormErrors {
+  email: string
+  password: string
+}
+
+const LoginPage = () => {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [errors, setErrors] = useState<FormErrors>({ email: '', password: '' })
+  const navigate = useNavigate()
+  const auth = useAuth()
+
+  const validate = () => {
+    const newErrors: FormErrors = { email: '', password: '' }
+    if (!/^\S+@\S+\.\S+$/.test(email)) {
+      newErrors.email = 'Invalid email'
+    }
+    if (!password) {
+      newErrors.password = 'Password required'
+    }
+    setErrors(newErrors)
+    return !newErrors.email && !newErrors.password
+  }
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (!validate()) return
+    try {
+      const res = await api.post('/login', { email, password })
+      const { token } = res.data
+      if (token) {
+        localStorage.setItem('token', token)
+        auth.login(email, () => navigate('/'))
+      }
+    } catch {
+      alert('Login failed. Check credentials.')
+    }
+  }
+
+  return (
+    <div className="login-page">
+      <div className="left-panel">
+        <div className="illustration" />
+      </div>
+      <div className="right-panel">
+        <form onSubmit={handleSubmit} className="login-form">
+          <h2>Welcome!</h2>
+          <div className="form-group">
+            <input
+              type="email"
+              placeholder="Your E-mail"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            {errors.email && <span className="error">{errors.email}</span>}
+          </div>
+          <div className="form-group">
+            <input
+              type="password"
+              placeholder="Your Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            {errors.password && (
+              <span className="error">{errors.password}</span>
+            )}
+          </div>
+          <div className="actions">
+            <label className="remember">
+              <input type="checkbox" /> Remember my password
+            </label>
+            <a href="#" className="forgot">
+              Forgot your password?
+            </a>
+          </div>
+          <button type="submit" className="login-button">
+            LOGIN
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default LoginPage

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,17 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: 'http://your-laravel-domain.test/api',
+  withCredentials: true,
+})
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token')
+  if (token) {
+    if (!config.headers) config.headers = {}
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
+
+export default api


### PR DESCRIPTION
## Summary
- implement auth context, protected routes, and simple layout
- add Axios API service with token interceptor
- create LoginPage with form validation and API call
- add placeholder Home and Dashboard pages
- remove obsolete Login page
- provide example Laravel JWT API routes and controller

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cf2afd5e8832bbf53bb798e31b413