### PR TITLE
Implement login page and context

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -1,35 +1,61 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useState } from 'react'
 
-interface AuthContextType {
-  login: (email: string, callback: () => void) => void
-  logout: (callback: () => void) => void
+interface User {
+  id: number
+  name: string
+  email: string
+  role: string | null
 }
 
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
+interface AuthContextType {
+  user: User | null
+  token: string | null
+  login: (token: string, user: User) => void
+  logout: () => void
+}
 
-export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const login = (email: string, callback: () => void) => {
-    console.log(`Logged in as ${email}`)
-    callback()
+const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [token, setToken] = useState<string | null>(
+    localStorage.getItem('his_token')
+  )
+  const [user, setUser] = useState<User | null>(() => {
+    const stored = localStorage.getItem('his_user')
+    return stored ? (JSON.parse(stored) as User) : null
+  })
+
+  const login = (newToken: string, newUser: User) => {
+    setToken(newToken)
+    setUser(newUser)
+    localStorage.setItem('his_token', newToken)
+    localStorage.setItem('his_user', JSON.stringify(newUser))
+    if (newUser.role) {
+      localStorage.setItem('his_role', newUser.role)
+    }
   }
 
-  const logout = (callback: () => void) => {
+  const logout = () => {
+    setToken(null)
+    setUser(null)
     localStorage.removeItem('his_token')
+    localStorage.removeItem('his_user')
     localStorage.removeItem('his_role')
-    callback()
   }
 
   return (
-    <AuthContext.Provider value={{ login, logout }}>
+    <AuthContext.Provider value={{ user, token, login, logout }}>
       {children}
     </AuthContext.Provider>
-  );
-};
+  )
+}
 
 export const useAuth = (): AuthContextType => {
-  const context = useContext(AuthContext);
+  const context = useContext(AuthContext)
   if (!context) {
-    throw new Error('useAuth must be used within an AuthProvider');
+    throw new Error('useAuth must be used within an AuthProvider')
   }
-  return context;
-};
+  return context
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -5,8 +5,8 @@ const api = axios.create({
   withCredentials: false,
 })
 
-api.interceptors.request.use(config => {
-  const token = localStorage.getItem('token')
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('his_token')
   if (token) config.headers.Authorization = `Bearer ${token}`
   return config
 })


### PR DESCRIPTION
## Summary
- store JWT token and user info in `AuthContext`
- update API service to send Authorization header using `his_token`
- handle login with AuthContext in `LoginPage`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef41da804832b892a713f6e493ad8