### PR TITLE
Add Admission module with nested routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,16 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Navigate,
+} from 'react-router-dom'
 import LoginPage from './pages/LoginPage'
 import Dashboard from './pages/Dashboard'
 import Homepage from './pages/Homepage'
 import ProtectedRoute from './auth/ProtectedRoute';
+import AdmissionLayout from './pages/admission/AdmissionLayout'
+import DaftarPasien from './pages/admission/DaftarPasien'
+import FormPasienBaru from './pages/admission/FormPasienBaru'
 
 function App() {
   return (
@@ -15,6 +23,11 @@ function App() {
         <Route element={<ProtectedRoute />}>
           <Route path="/homepage" element={<Homepage />} />
           <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/admission" element={<AdmissionLayout />}>
+            <Route index element={<Navigate to="daftar-pasien" replace />} />
+            <Route path="daftar-pasien" element={<DaftarPasien />} />
+            <Route path="form-pasien-baru" element={<FormPasienBaru />} />
+          </Route>
         </Route>
 
         {/* Optional: tambahkan route default atau 404 */}

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -20,6 +20,9 @@ const Homepage: React.FC = () => {
             <Link to="/homepage">Dashboard</Link>
           </li>
           <li>
+            <Link to="/admission">Admission</Link>
+          </li>
+          <li>
             <Link to="#">Settings</Link>
           </li>
           <li>

--- a/src/pages/admission/AdmissionLayout.tsx
+++ b/src/pages/admission/AdmissionLayout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router-dom'
+
+const AdmissionLayout: React.FC = () => {
+  return (
+    <div className="admission-module">
+      <Outlet />
+    </div>
+  )
+}
+
+export default AdmissionLayout

--- a/src/pages/admission/DaftarPasien.tsx
+++ b/src/pages/admission/DaftarPasien.tsx
@@ -1,0 +1,68 @@
+import { useNavigate } from 'react-router-dom'
+
+interface Pasien {
+  noRm: string
+  nama: string
+  tanggalLahir: string
+  alamat: string
+  status: string
+}
+
+const mockData: Pasien[] = [
+  {
+    noRm: '001',
+    nama: 'John Doe',
+    tanggalLahir: '1990-01-01',
+    alamat: 'Jakarta',
+    status: 'Aktif',
+  },
+  {
+    noRm: '002',
+    nama: 'Jane Smith',
+    tanggalLahir: '1985-05-12',
+    alamat: 'Bandung',
+    status: 'Non Aktif',
+  },
+]
+
+const DaftarPasien: React.FC = () => {
+  const navigate = useNavigate()
+
+  return (
+    <div>
+      <h2>Daftar Pasien</h2>
+      <button onClick={() => navigate('/admission/form-pasien-baru')}>
+        Daftarkan Pasien
+      </button>
+      <table className="pasien-table">
+        <thead>
+          <tr>
+            <th>No RM</th>
+            <th>Nama Pasien</th>
+            <th>Tanggal Lahir</th>
+            <th>Alamat</th>
+            <th>Status</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {mockData.map((p, index) => (
+            <tr key={index}>
+              <td>{p.noRm}</td>
+              <td>{p.nama}</td>
+              <td>{p.tanggalLahir}</td>
+              <td>{p.alamat}</td>
+              <td>{p.status}</td>
+              <td>
+                <button className="edit-btn">Edit</button>{' '}
+                <button className="delete-btn">Delete</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default DaftarPasien

--- a/src/pages/admission/FormPasienBaru.tsx
+++ b/src/pages/admission/FormPasienBaru.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+
+const FormPasienBaru: React.FC = () => {
+  const [nama, setNama] = useState('')
+  const [alamat, setAlamat] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    console.log({ nama, alamat })
+    setNama('')
+    setAlamat('')
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="form-pasien-baru">
+      <h2>Form Pasien Baru</h2>
+      <div>
+        <label>Nama Pasien</label>
+        <input
+          type="text"
+          value={nama}
+          onChange={(e) => setNama(e.target.value)}
+        />
+      </div>
+      <div>
+        <label>Alamat</label>
+        <input
+          type="text"
+          value={alamat}
+          onChange={(e) => setAlamat(e.target.value)}
+        />
+      </div>
+      <button type="submit">Submit</button>
+    </form>
+  )
+}
+
+export default FormPasienBaru


### PR DESCRIPTION
## Summary
- create Admission layout and pages
- setup nested routes under `/admission`
- add Admission link to dashboard sidebar

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684efd01be18832ba06891c59df18931