### PR TITLE
Fix patient form imports

### DIFF
--- a/src/pages/admission/FormPasienBaru.tsx
+++ b/src/pages/admission/FormPasienBaru.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react'
-import NomorIdentitasPanel from '../components/form-panels/NomorIdentitasPanel'
-import DataPasienPanel from '../components/form-panels/DataPasienPanel'
-import AlamatIdentitasPanel from '../components/form-panels/AlamatIdentitasPanel'
-import AlamatDomisiliPanel from '../components/form-panels/AlamatDomisiliPanel'
-import KontakPanel from '../components/form-panels/KontakPanel'
-import KontakDaruratPanel from '../components/form-panels/KontakDaruratPanel'
-import HubunganKeluargaPanel from '../components/form-panels/HubunganKeluargaPanel'
+import NomorIdentitasPanel from '../../components/form-panels/NomorIdentitasPanel'
+import DataPasienPanel from '../../components/form-panels/DataPasienPanel'
+import AlamatIdentitasPanel from '../../components/form-panels/AlamatIdentitasPanel'
+import AlamatDomisiliPanel from '../../components/form-panels/AlamatDomisiliPanel'
+import KontakPanel from '../../components/form-panels/KontakPanel'
+import KontakDaruratPanel from '../../components/form-panels/KontakDaruratPanel'
+import HubunganKeluargaPanel from '../../components/form-panels/HubunganKeluargaPanel'
 
 const FormPasienBaru: React.FC = () => {
   const [form, setForm] = useState({


### PR DESCRIPTION
## Summary
- fix relative import paths in `FormPasienBaru` so the admission form can load panel components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd273f65c832babc3110e0607378b