### PR TITLE
Fix form typing reuse

### DIFF
--- a/src/components/form-panels/AlamatDomisiliPanel.tsx
+++ b/src/components/form-panels/AlamatDomisiliPanel.tsx
@@ -1,19 +1,14 @@
 import React from 'react'
+import { AddressForm } from './types'
 
 interface Props {
   sameAsIdentity: boolean
-  data: {
-    searchRegion: string
-    village: string
-    subDistrict: string
-    city: string
-    province: string
-    regionCode: string
-    rt: string
-    rw: string
-  }
+  data: AddressForm
   onSameAsIdentityChange: (value: boolean) => void
-  onChange: (field: string, value: string) => void
+  onChange: <K extends keyof AddressForm>(
+    field: K,
+    value: AddressForm[K],
+  ) => void
 }
 
 const AlamatDomisiliPanel: React.FC<Props> = ({ sameAsIdentity, data, onSameAsIdentityChange, onChange }) => (

--- a/src/components/form-panels/AlamatIdentitasPanel.tsx
+++ b/src/components/form-panels/AlamatIdentitasPanel.tsx
@@ -1,17 +1,12 @@
 import React from 'react'
+import { AddressForm } from './types'
 
 interface Props {
-  data: {
-    searchRegion: string
-    village: string
-    subDistrict: string
-    city: string
-    province: string
-    regionCode: string
-    rt: string
-    rw: string
-  }
-  onChange: (field: string, value: string) => void
+  data: AddressForm
+  onChange: <K extends keyof AddressForm>(
+    field: K,
+    value: AddressForm[K],
+  ) => void
 }
 
 const AlamatIdentitasPanel: React.FC<Props> = ({ data, onChange }) => (

--- a/src/components/form-panels/DataPasienPanel.tsx
+++ b/src/components/form-panels/DataPasienPanel.tsx
@@ -1,22 +1,12 @@
 import React from 'react'
+import { PatientDataForm } from './types'
 
 interface Props {
-  data: {
-    salutation: string
-    fullName: string
-    placeOfBirth: string
-    dateOfBirth: string
-    gender: string
-    maritalStatus: string
-    country: string
-    bloodType: string
-    religion: string
-    language: string
-    ethnicity: string
-    lastEducation: string
-    occupation: string
-  }
-  onChange: (field: string, value: string) => void
+  data: PatientDataForm
+  onChange: <K extends keyof PatientDataForm>(
+    field: K,
+    value: PatientDataForm[K],
+  ) => void
 }
 
 const DataPasienPanel: React.FC<Props> = ({ data, onChange }) => (

--- a/src/components/form-panels/KontakDaruratPanel.tsx
+++ b/src/components/form-panels/KontakDaruratPanel.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
+import { EmergencyContactForm } from './types'
 
 interface Props {
-  data: {
-    relationship: string
-    name: string
-    countryCode: string
-    phoneNumber: string
-    email: string
-    address: string
-  }
-  onChange: (field: string, value: string) => void
+  data: EmergencyContactForm
+  onChange: <K extends keyof EmergencyContactForm>(
+    field: K,
+    value: EmergencyContactForm[K],
+  ) => void
 }
 
 const KontakDaruratPanel: React.FC<Props> = ({ data, onChange }) => (

--- a/src/components/form-panels/KontakPanel.tsx
+++ b/src/components/form-panels/KontakPanel.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
+import { ContactForm } from './types'
 
 interface Props {
-  data: {
-    countryCode: string
-    phoneNumber: string
-    email: string
-  }
-  onChange: (field: string, value: string) => void
+  data: ContactForm
+  onChange: <K extends keyof ContactForm>(
+    field: K,
+    value: ContactForm[K],
+  ) => void
 }
 
 const KontakPanel: React.FC<Props> = ({ data, onChange }) => (

--- a/src/components/form-panels/NomorIdentitasPanel.tsx
+++ b/src/components/form-panels/NomorIdentitasPanel.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
+import { IdentityNumberForm } from './types'
 
 interface Props {
-  data: {
-    nationality: string
-    idType: string
-    idNumber: string
-  }
-  onChange: (field: string, value: string) => void
+  data: IdentityNumberForm
+  onChange: <K extends keyof IdentityNumberForm>(
+    field: K,
+    value: IdentityNumberForm[K],
+  ) => void
 }
 
 const NomorIdentitasPanel: React.FC<Props> = ({ data, onChange }) => (

--- a/src/components/form-panels/types.ts
+++ b/src/components/form-panels/types.ts
@@ -1,0 +1,120 @@
+export interface IdentityNumberForm {
+  nationality: string
+  idType: string
+  idNumber: string
+}
+
+export interface PatientDataForm {
+  salutation: string
+  fullName: string
+  placeOfBirth: string
+  dateOfBirth: string
+  gender: string
+  maritalStatus: string
+  country: string
+  bloodType: string
+  religion: string
+  language: string
+  ethnicity: string
+  lastEducation: string
+  occupation: string
+}
+
+export interface AddressForm {
+  searchRegion: string
+  village: string
+  subDistrict: string
+  city: string
+  province: string
+  regionCode: string
+  rt: string
+  rw: string
+}
+
+export interface ContactForm {
+  countryCode: string
+  phoneNumber: string
+  email: string
+}
+
+export interface EmergencyContactForm {
+  relationship: string
+  name: string
+  countryCode: string
+  phoneNumber: string
+  email: string
+  address: string
+}
+
+export interface FormState {
+  emergency: boolean
+  identityNumber: IdentityNumberForm
+  patientData: PatientDataForm
+  identityAddress: AddressForm
+  sameAsIdentity: boolean
+  domicileAddress: AddressForm
+  contact: ContactForm
+  emergencyContact: EmergencyContactForm
+  familyPatient: string
+}
+
+export type SectionKey =
+  | 'identityNumber'
+  | 'patientData'
+  | 'identityAddress'
+  | 'domicileAddress'
+  | 'contact'
+  | 'emergencyContact'
+
+export type SimpleKey = 'emergency' | 'sameAsIdentity' | 'familyPatient'
+
+export const initialState: FormState = {
+  emergency: false,
+  identityNumber: { nationality: '', idType: '', idNumber: '' },
+  patientData: {
+    salutation: '',
+    fullName: '',
+    placeOfBirth: '',
+    dateOfBirth: '',
+    gender: '',
+    maritalStatus: '',
+    country: '',
+    bloodType: '',
+    religion: '',
+    language: '',
+    ethnicity: '',
+    lastEducation: '',
+    occupation: '',
+  },
+  identityAddress: {
+    searchRegion: '',
+    village: '',
+    subDistrict: '',
+    city: '',
+    province: '',
+    regionCode: '',
+    rt: '',
+    rw: '',
+  },
+  sameAsIdentity: false,
+  domicileAddress: {
+    searchRegion: '',
+    village: '',
+    subDistrict: '',
+    city: '',
+    province: '',
+    regionCode: '',
+    rt: '',
+    rw: '',
+  },
+  contact: { countryCode: '', phoneNumber: '', email: '' },
+  emergencyContact: {
+    relationship: '',
+    name: '',
+    countryCode: '',
+    phoneNumber: '',
+    email: '',
+    address: '',
+  },
+  familyPatient: '',
+}

--- a/src/pages/admission/FormPasienBaru.tsx
+++ b/src/pages/admission/FormPasienBaru.tsx
@@ -6,36 +6,40 @@ import AlamatDomisiliPanel from '../../components/form-panels/AlamatDomisiliPane
 import KontakPanel from '../../components/form-panels/KontakPanel'
 import KontakDaruratPanel from '../../components/form-panels/KontakDaruratPanel'
 import HubunganKeluargaPanel from '../../components/form-panels/HubunganKeluargaPanel'
+import {
+  FormState,
+  SectionKey,
+  SimpleKey,
+  initialState,
+} from '../../components/form-panels/types'
+
 
 const FormPasienBaru: React.FC = () => {
-  const [form, setForm] = useState({
-    emergency: false,
-    identityNumber: { nationality: '', idType: '', idNumber: '' },
-    patientData: { salutation: '', fullName: '', placeOfBirth: '', dateOfBirth: '', gender: '', maritalStatus: '', country: '', bloodType: '', religion: '', language: '', ethnicity: '', lastEducation: '', occupation: '' },
-    identityAddress: { searchRegion: '', village: '', subDistrict: '', city: '', province: '', regionCode: '', rt: '', rw: '' },
-    sameAsIdentity: false,
-    domicileAddress: { searchRegion: '', village: '', subDistrict: '', city: '', province: '', regionCode: '', rt: '', rw: '' },
-    contact: { countryCode: '', phoneNumber: '', email: '' },
-    emergencyContact: { relationship: '', name: '', countryCode: '', phoneNumber: '', email: '', address: '' },
-    familyPatient: ''
-  })
+  const [form, setForm] = useState<FormState>(initialState)
 
   const [showPopup, setShowPopup] = useState(false)
 
-  const handleChange = (section: string, field: string, value: any) => {
+  const handleChange = <S extends SectionKey>(
+    section: S,
+    field: keyof FormState[S],
+    value: FormState[S][keyof FormState[S]],
+  ) => {
     setForm(prev => ({
       ...prev,
       [section]: {
         ...prev[section],
-        [field]: value
-      }
+        [field]: value,
+      },
     }))
   }
 
-  const handleSimpleChange = (field: string, value: any) => {
+  const handleSimpleChange = <S extends SimpleKey>(
+    field: S,
+    value: FormState[S],
+  ) => {
     setForm(prev => ({
       ...prev,
-      [field]: value
+      [field]: value,
     }))
   }
 


### PR DESCRIPTION
## Summary
- centralize form interfaces into a reusable types file
- update form panels to use the shared interfaces
- simplify FormPasienBaru by importing the shared types

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684fd66564d0832b8f43be2a44ccabfd