### PR TITLE
Implement Tailwind and toast

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import App from '../App';
+
+describe('App Component', () => {
+  it('renders the App component without crashing', () => {
+    render(<App />);
+    expect(screen.getByText(/dashboard/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,1 +1,7 @@
-isi
+const Header: React.FC = () => (
+  <header className="navbar bg-blue-600 text-white p-4">
+    <h1 className="text-lg font-bold">HIS</h1>
+  </header>
+)
+
+export default Header

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,1 +1,18 @@
-isi
+import { Link } from 'react-router-dom'
+
+const Sidebar: React.FC = () => (
+  <aside className="sidebar bg-gray-100 p-4">
+    <nav>
+      <ul className="space-y-2">
+        <li>
+          <Link to="/dashboard">Dashboard</Link>
+        </li>
+        <li>
+          <Link to="/admission">Admission</Link>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+)
+
+export default Sidebar

--- a/src/components/SuccessToast.tsx
+++ b/src/components/SuccessToast.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react'
+
+interface SuccessToastProps {
+  message: string
+  onClose: () => void
+}
+
+const SuccessToast: React.FC<SuccessToastProps> = ({ message, onClose }) => {
+  useEffect(() => {
+    const timer = setTimeout(onClose, 2000)
+    return () => clearTimeout(timer)
+  }, [onClose])
+
+  return (
+    <div className="fixed bottom-4 right-4 bg-green-500 text-white px-4 py-2 rounded shadow">
+      {message}
+    </div>
+  )
+}
+
+export default SuccessToast

--- a/src/pages/admission/FormPasienBaru.tsx
+++ b/src/pages/admission/FormPasienBaru.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import NomorIdentitasPanel from '../../components/form-panels/NomorIdentitasPanel'
 import DataPasienPanel from '../../components/form-panels/DataPasienPanel'
 import AlamatIdentitasPanel from '../../components/form-panels/AlamatIdentitasPanel'
@@ -6,6 +6,7 @@ import AlamatDomisiliPanel from '../../components/form-panels/AlamatDomisiliPane
 import KontakPanel from '../../components/form-panels/KontakPanel'
 import KontakDaruratPanel from '../../components/form-panels/KontakDaruratPanel'
 import HubunganKeluargaPanel from '../../components/form-panels/HubunganKeluargaPanel'
+import SuccessToast from '../../components/SuccessToast'
 
 import type { PatientFormState, SectionKey, SimpleKey } from '../../components/form-panels/types'
 import { initialState } from '../../components/form-panels/types'
@@ -15,13 +16,6 @@ const FormPasienBaru: React.FC = () => {
   const [form, setForm] = useState<PatientFormState>(initialState)
 
   const [showPopup, setShowPopup] = useState(false)
-
-  useEffect(() => {
-    if (showPopup) {
-      const timer = setTimeout(() => setShowPopup(false), 2000)
-      return () => clearTimeout(timer)
-    }
-  }, [showPopup])
 
   const handleChange = <S extends SectionKey, F extends keyof PatientFormState[S]>(
     section: S,
@@ -119,9 +113,10 @@ const FormPasienBaru: React.FC = () => {
       </form>
 
       {showPopup && (
-        <div style={{ marginTop: '1rem', color: 'green' }}>
-          Data Tersimpan
-        </div>
+        <SuccessToast
+          message="Data Tersimpan"
+          onClose={() => setShowPopup(false)}
+        />
       )}
     </div>
   )

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Summary
- add Tailwind config and PostCSS setup
- enable Tailwind in global styles
- implement Header and Sidebar components
- add SuccessToast component and use it in patient form
- set up vitest and add a basic test

## Testing
- `npm test` *(failed: vitest not found)*