### PR TITLE
Fix PostCSS Tailwind plugin usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "plop": "^4.0.1",
     "postcss": "^8.5.5",
     "tailwindcss": "^4.1.10",
+    "@tailwindcss/postcss": "^0.1.0",
     "typescript": "^5.8.3",
     "vite": "^6.3.5",
     "vitest": "^3.2.4"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,5 @@
+import tailwindcss from '@tailwindcss/postcss'
+
 export default {
   plugins: {
     tailwindcss: {},


### PR DESCRIPTION
## Summary
- update postcss config to use `@tailwindcss/postcss`
- add the plugin to dev dependencies

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68531949d554832bb82425d22b6043e7