### PR TITLE
Fix Tailwind PostCSS plugin usage

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,8 +1,6 @@
-import tailwindcss from '@tailwindcss/postcss'
+import tailwindcss from '@tailwindcss/postcss';
+import autoprefixer from 'autoprefixer';
 
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}
+  plugins: [tailwindcss, autoprefixer],
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  plugins: [
-    require('@tailwindcss/postcss'),
-    require('autoprefixer'),
-  ],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
 };


### PR DESCRIPTION
## Summary
- update PostCSS config to use `@tailwindcss/postcss`
- clean up `tailwind.config.js`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685327eb5fec832b8cc5d3da5c7e39d0