### PR TITLE
Add Tailwind styling for admission pages

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary'
+}
+
+const base = 'px-4 py-2 rounded focus:outline-none focus:ring text-sm'
+const variants = {
+  primary: `${base} bg-blue-600 text-white hover:bg-blue-700`,
+  secondary: `${base} bg-gray-200 text-gray-800 hover:bg-gray-300`,
+}
+
+const Button: React.FC<ButtonProps> = ({ variant = 'primary', className = '', ...props }) => (
+  <button className={`${variants[variant]} ${className}`} {...props} />
+)
+
+export default Button

--- a/src/components/form-panels/AlamatDomisiliPanel.tsx
+++ b/src/components/form-panels/AlamatDomisiliPanel.tsx
@@ -12,10 +12,10 @@ interface Props {
 }
 
 const AlamatDomisiliPanel: React.FC<Props> = ({ sameAsIdentity, data, onSameAsIdentityChange, onChange }) => (
-  <fieldset>
-    <legend>Domicile Address</legend>
-    <div>
-      <label>
+  <fieldset className="border rounded p-4 space-y-3">
+    <legend className="font-medium">Domicile Address</legend>
+    <div className="space-y-1">
+      <label className="block text-sm">
         <input
           type="checkbox"
           checked={sameAsIdentity}
@@ -26,37 +26,37 @@ const AlamatDomisiliPanel: React.FC<Props> = ({ sameAsIdentity, data, onSameAsId
     </div>
     {!sameAsIdentity && (
       <>
-        <div>
-          <label>Search Region:</label>
-          <input type="text" value={data.searchRegion} onChange={e => onChange('searchRegion', e.target.value)} />
+        <div className="space-y-1">
+          <label className="block text-sm">Search Region:</label>
+          <input className="w-full border rounded p-2" type="text" value={data.searchRegion} onChange={e => onChange('searchRegion', e.target.value)} />
         </div>
-        <div>
-          <label>Village:</label>
-          <input type="text" value={data.village} onChange={e => onChange('village', e.target.value)} />
+        <div className="space-y-1">
+          <label className="block text-sm">Village:</label>
+          <input className="w-full border rounded p-2" type="text" value={data.village} onChange={e => onChange('village', e.target.value)} />
         </div>
-        <div>
-          <label>Sub-district:</label>
-          <input type="text" value={data.subDistrict} onChange={e => onChange('subDistrict', e.target.value)} />
+        <div className="space-y-1">
+          <label className="block text-sm">Sub-district:</label>
+          <input className="w-full border rounded p-2" type="text" value={data.subDistrict} onChange={e => onChange('subDistrict', e.target.value)} />
         </div>
-        <div>
-          <label>City/Regency:</label>
-          <input type="text" value={data.city} onChange={e => onChange('city', e.target.value)} />
+        <div className="space-y-1">
+          <label className="block text-sm">City/Regency:</label>
+          <input className="w-full border rounded p-2" type="text" value={data.city} onChange={e => onChange('city', e.target.value)} />
         </div>
-        <div>
-          <label>Province:</label>
-          <input type="text" value={data.province} onChange={e => onChange('province', e.target.value)} />
+        <div className="space-y-1">
+          <label className="block text-sm">Province:</label>
+          <input className="w-full border rounded p-2" type="text" value={data.province} onChange={e => onChange('province', e.target.value)} />
         </div>
-        <div>
-          <label>Region Code:</label>
-          <input type="text" value={data.regionCode} onChange={e => onChange('regionCode', e.target.value)} />
+        <div className="space-y-1">
+          <label className="block text-sm">Region Code:</label>
+          <input className="w-full border rounded p-2" type="text" value={data.regionCode} onChange={e => onChange('regionCode', e.target.value)} />
         </div>
-        <div>
-          <label>RT:</label>
-          <input type="text" value={data.rt} onChange={e => onChange('rt', e.target.value)} />
+        <div className="space-y-1">
+          <label className="block text-sm">RT:</label>
+          <input className="w-full border rounded p-2" type="text" value={data.rt} onChange={e => onChange('rt', e.target.value)} />
         </div>
-        <div>
-          <label>RW:</label>
-          <input type="text" value={data.rw} onChange={e => onChange('rw', e.target.value)} />
+        <div className="space-y-1">
+          <label className="block text-sm">RW:</label>
+          <input className="w-full border rounded p-2" type="text" value={data.rw} onChange={e => onChange('rw', e.target.value)} />
         </div>
       </>
     )}

--- a/src/components/form-panels/AlamatIdentitasPanel.tsx
+++ b/src/components/form-panels/AlamatIdentitasPanel.tsx
@@ -10,39 +10,39 @@ interface Props {
 }
 
 const AlamatIdentitasPanel: React.FC<Props> = ({ data, onChange }) => (
-  <fieldset>
-    <legend>Identity Address</legend>
-    <div>
-      <label>Search Region:</label>
-      <input type="text" value={data.searchRegion} onChange={e => onChange('searchRegion', e.target.value)} />
+  <fieldset className="border rounded p-4 space-y-3">
+    <legend className="font-medium">Identity Address</legend>
+    <div className="space-y-1">
+      <label className="block text-sm">Search Region:</label>
+      <input className="w-full border rounded p-2" type="text" value={data.searchRegion} onChange={e => onChange('searchRegion', e.target.value)} />
     </div>
-    <div>
-      <label>Village:</label>
-      <input type="text" value={data.village} onChange={e => onChange('village', e.target.value)} />
+    <div className="space-y-1">
+      <label className="block text-sm">Village:</label>
+      <input className="w-full border rounded p-2" type="text" value={data.village} onChange={e => onChange('village', e.target.value)} />
     </div>
-    <div>
-      <label>Sub-district:</label>
-      <input type="text" value={data.subDistrict} onChange={e => onChange('subDistrict', e.target.value)} />
+    <div className="space-y-1">
+      <label className="block text-sm">Sub-district:</label>
+      <input className="w-full border rounded p-2" type="text" value={data.subDistrict} onChange={e => onChange('subDistrict', e.target.value)} />
     </div>
-    <div>
-      <label>City/Regency:</label>
-      <input type="text" value={data.city} onChange={e => onChange('city', e.target.value)} />
+    <div className="space-y-1">
+      <label className="block text-sm">City/Regency:</label>
+      <input className="w-full border rounded p-2" type="text" value={data.city} onChange={e => onChange('city', e.target.value)} />
     </div>
-    <div>
-      <label>Province:</label>
-      <input type="text" value={data.province} onChange={e => onChange('province', e.target.value)} />
+    <div className="space-y-1">
+      <label className="block text-sm">Province:</label>
+      <input className="w-full border rounded p-2" type="text" value={data.province} onChange={e => onChange('province', e.target.value)} />
     </div>
-    <div>
-      <label>Region Code:</label>
-      <input type="text" value={data.regionCode} onChange={e => onChange('regionCode', e.target.value)} />
+    <div className="space-y-1">
+      <label className="block text-sm">Region Code:</label>
+      <input className="w-full border rounded p-2" type="text" value={data.regionCode} onChange={e => onChange('regionCode', e.target.value)} />
     </div>
-    <div>
-      <label>RT:</label>
-      <input type="text" value={data.rt} onChange={e => onChange('rt', e.target.value)} />
+    <div className="space-y-1">
+      <label className="block text-sm">RT:</label>
+      <input className="w-full border rounded p-2" type="text" value={data.rt} onChange={e => onChange('rt', e.target.value)} />
     </div>
-    <div>
-      <label>RW:</label>
-      <input type="text" value={data.rw} onChange={e => onChange('rw', e.target.value)} />
+    <div className="space-y-1">
+      <label className="block text-sm">RW:</label>
+      <input className="w-full border rounded p-2" type="text" value={data.rw} onChange={e => onChange('rw', e.target.value)} />
     </div>
   </fieldset>
 )

--- a/src/components/form-panels/DataPasienPanel.tsx
+++ b/src/components/form-panels/DataPasienPanel.tsx
@@ -10,61 +10,70 @@ interface Props {
 }
 
 const DataPasienPanel: React.FC<Props> = ({ data, onChange }) => (
-  <fieldset>
-    <legend>Patient Data</legend>
-    <div>
-      <label>Upload Photo:</label>
-      <input type="file" disabled />
+  <fieldset className="border rounded p-4 space-y-3">
+    <legend className="font-medium">Patient Data</legend>
+    
+    <div className="space-y-1">
+      <label className="block text-sm">Upload Photo:</label>
+      <input className="w-full border rounded p-2" type="file" disabled />
     </div>
-    <div>
-      <label>Salutation:</label>
-      <select value={data.salutation} onChange={e => onChange('salutation', e.target.value)}>
+    
+    <div className="space-y-1">
+      <label className="block text-sm">Salutation:</label>
+      <select className="w-full border rounded p-2" value={data.salutation} onChange={e => onChange('salutation', e.target.value)}>
         <option value="">-- Select --</option>
         <option value="Tn">Tn</option>
         <option value="Ny">Ny</option>
         <option value="Sdri">Sdri</option>
       </select>
     </div>
-    <div>
-      <label>Full Name:</label>
-      <input type="text" value={data.fullName} onChange={e => onChange('fullName', e.target.value)} />
+    
+    <div className="space-y-1">
+      <label className="block text-sm">Full Name:</label>
+      <input className="w-full border rounded p-2" type="text" value={data.fullName} onChange={e => onChange('fullName', e.target.value)} />
     </div>
-    <div>
-      <label>Place of Birth:</label>
-      <input type="text" value={data.placeOfBirth} onChange={e => onChange('placeOfBirth', e.target.value)} />
+    
+    <div className="space-y-1">
+      <label className="block text-sm">Place of Birth:</label>
+      <input className="w-full border rounded p-2" type="text" value={data.placeOfBirth} onChange={e => onChange('placeOfBirth', e.target.value)} />
     </div>
-    <div>
-      <label>Date of Birth:</label>
-      <input type="date" value={data.dateOfBirth} onChange={e => onChange('dateOfBirth', e.target.value)} />
+    
+    <div className="space-y-1">
+      <label className="block text-sm">Date of Birth:</label>
+      <input className="w-full border rounded p-2" type="date" value={data.dateOfBirth} onChange={e => onChange('dateOfBirth', e.target.value)} />
     </div>
-    <div>
-      <label>Gender:</label>
-      <select value={data.gender} onChange={e => onChange('gender', e.target.value)}>
+    
+    <div className="space-y-1">
+      <label className="block text-sm">Gender:</label>
+      <select className="w-full border rounded p-2" value={data.gender} onChange={e => onChange('gender', e.target.value)}>
         <option value="">-- Select --</option>
         <option value="Male">Male</option>
         <option value="Female">Female</option>
       </select>
     </div>
-    <div>
-      <label>Marital Status:</label>
-      <select value={data.maritalStatus} onChange={e => onChange('maritalStatus', e.target.value)}>
+    
+    <div className="space-y-1">
+      <label className="block text-sm">Marital Status:</label>
+      <select className="w-full border rounded p-2" value={data.maritalStatus} onChange={e => onChange('maritalStatus', e.target.value)}>
         <option value="">-- Select --</option>
         <option value="Single">Single</option>
         <option value="Married">Married</option>
         <option value="Divorced">Divorced</option>
       </select>
     </div>
-    <div>
-      <label>Country:</label>
-      <select value={data.country} onChange={e => onChange('country', e.target.value)}>
+    
+    <div className="space-y-1">
+      <label className="block text-sm">Country:</label>
+      <select className="w-full border rounded p-2" value={data.country} onChange={e => onChange('country', e.target.value)}>
         <option value="">-- Select --</option>
         <option value="Indonesia">Indonesia</option>
         <option value="USA">USA</option>
       </select>
     </div>
-    <div>
-      <label>Blood Type:</label>
-      <select value={data.bloodType} onChange={e => onChange('bloodType', e.target.value)}>
+    
+    <div className="space-y-1">
+      <label className="block text-sm">Blood Type:</label>
+      <select className="w-full border rounded p-2" value={data.bloodType} onChange={e => onChange('bloodType', e.target.value)}>
         <option value="">-- Select --</option>
         <option value="A+">A+</option>
         <option value="A-">A-</option>
@@ -76,18 +85,20 @@ const DataPasienPanel: React.FC<Props> = ({ data, onChange }) => (
         <option value="O-">O-</option>
       </select>
     </div>
-    <div>
-      <label>Religion:</label>
-      <select value={data.religion} onChange={e => onChange('religion', e.target.value)}>
+    
+    <div className="space-y-1">
+      <label className="block text-sm">Religion:</label>
+      <select className="w-full border rounded p-2" value={data.religion} onChange={e => onChange('religion', e.target.value)}>
         <option value="">-- Select --</option>
         <option value="Islam">Islam</option>
         <option value="Christian">Christian</option>
         <option value="Catholic">Catholic</option>
       </select>
     </div>
-    <div>
-      <label>Language:</label>
-      <select value={data.language} onChange={e => onChange('language', e.target.value)}>
+    
+    <div className="space-y-1">
+      <label className="block text-sm">Language:</label>
+      <select className="w-full border rounded p-2" value={data.language} onChange={e => onChange('language', e.target.value)}>
         <option value="">-- Select --</option>
         <option value="Indonesian">Indonesian</option>
         <option value="English">English</option>
@@ -96,9 +107,10 @@ const DataPasienPanel: React.FC<Props> = ({ data, onChange }) => (
         <option value="Sundanese">Sundanese</option>
       </select>
     </div>
-    <div>
-      <label>Ethnicity:</label>
-      <select value={data.ethnicity} onChange={e => onChange('ethnicity', e.target.value)}>
+    
+    <div className="space-y-1">
+      <label className="block text-sm">Ethnicity:</label>
+      <select className="w-full border rounded p-2" value={data.ethnicity} onChange={e => onChange('ethnicity', e.target.value)}>
         <option value="">-- Select --</option>
         <option value="Batak">Batak</option>
         <option value="Minang">Minang</option>
@@ -106,9 +118,10 @@ const DataPasienPanel: React.FC<Props> = ({ data, onChange }) => (
         <option value="Javanese">Javanese</option>
       </select>
     </div>
-    <div>
-      <label>Last Education:</label>
-      <select value={data.lastEducation} onChange={e => onChange('lastEducation', e.target.value)}>
+    
+    <div className="space-y-1">
+      <label className="block text-sm">Last Education:</label>
+      <select className="w-full border rounded p-2" value={data.lastEducation} onChange={e => onChange('lastEducation', e.target.value)}>
         <option value="">-- Select --</option>
         <option value="SD">SD</option>
         <option value="SMP">SMP</option>
@@ -118,9 +131,10 @@ const DataPasienPanel: React.FC<Props> = ({ data, onChange }) => (
         <option value="S3">S3</option>
       </select>
     </div>
-    <div>
-      <label>Occupation:</label>
-      <select value={data.occupation} onChange={e => onChange('occupation', e.target.value)}>
+    
+    <div className="space-y-1">
+      <label className="block text-sm">Occupation:</label>
+      <select className="w-full border rounded p-2" value={data.occupation} onChange={e => onChange('occupation', e.target.value)}>
         <option value="">-- Select --</option>
         <option value="Teacher">Teacher</option>
         <option value="Military">Military</option>

--- a/src/components/form-panels/HubunganKeluargaPanel.tsx
+++ b/src/components/form-panels/HubunganKeluargaPanel.tsx
@@ -6,11 +6,16 @@ interface Props {
 }
 
 const HubunganKeluargaPanel: React.FC<Props> = ({ value, onChange }) => (
-  <fieldset>
-    <legend>Family Relationship</legend>
-    <div>
-      <label>Search Family Patient:</label>
-      <input type="text" value={value} onChange={e => onChange(e.target.value)} />
+  <fieldset className="border rounded p-4 space-y-3">
+    <legend className="font-medium">Family Relationship</legend>
+    <div className="space-y-1">
+      <label className="block text-sm">Search Family Patient:</label>
+      <input
+        className="w-full border rounded p-2"
+        type="text"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+      />
     </div>
   </fieldset>
 )

--- a/src/components/form-panels/KontakDaruratPanel.tsx
+++ b/src/components/form-panels/KontakDaruratPanel.tsx
@@ -10,40 +10,40 @@ interface Props {
 }
 
 const KontakDaruratPanel: React.FC<Props> = ({ data, onChange }) => (
-  <fieldset>
-    <legend>Emergency Contact</legend>
-    <div>
-      <label>Relationship:</label>
-      <select value={data.relationship} onChange={e => onChange('relationship', e.target.value)}>
+  <fieldset className="border rounded p-4 space-y-3">
+    <legend className="font-medium">Emergency Contact</legend>
+    <div className="space-y-1">
+      <label className="block text-sm">Relationship:</label>
+      <select className="w-full border rounded p-2" value={data.relationship} onChange={e => onChange('relationship', e.target.value)}>
         <option value="">-- Select --</option>
         <option value="Ortu">Ortu</option>
         <option value="Pasangan">Pasangan</option>
         <option value="Teman">Teman</option>
       </select>
     </div>
-    <div>
-      <label>Name:</label>
-      <input type="text" value={data.name} onChange={e => onChange('name', e.target.value)} />
+    <div className="space-y-1">
+      <label className="block text-sm">Name:</label>
+      <input className="w-full border rounded p-2" type="text" value={data.name} onChange={e => onChange('name', e.target.value)} />
     </div>
-    <div>
-      <label>Country Code:</label>
-      <select value={data.countryCode} onChange={e => onChange('countryCode', e.target.value)}>
+    <div className="space-y-1">
+      <label className="block text-sm">Country Code:</label>
+      <select className="w-full border rounded p-2" value={data.countryCode} onChange={e => onChange('countryCode', e.target.value)}>
         <option value="">-- Select --</option>
         <option value="62">+62</option>
         <option value="1">+1</option>
       </select>
     </div>
-    <div>
-      <label>Phone Number:</label>
-      <input type="text" value={data.phoneNumber} onChange={e => onChange('phoneNumber', e.target.value)} />
+    <div className="space-y-1">
+      <label className="block text-sm">Phone Number:</label>
+      <input className="w-full border rounded p-2" type="text" value={data.phoneNumber} onChange={e => onChange('phoneNumber', e.target.value)} />
     </div>
-    <div>
-      <label>Email:</label>
-      <input type="email" value={data.email} onChange={e => onChange('email', e.target.value)} />
+    <div className="space-y-1">
+      <label className="block text-sm">Email:</label>
+      <input className="w-full border rounded p-2" type="email" value={data.email} onChange={e => onChange('email', e.target.value)} />
     </div>
-    <div>
-      <label>Address:</label>
-      <input type="text" value={data.address} onChange={e => onChange('address', e.target.value)} />
+    <div className="space-y-1">
+      <label className="block text-sm">Address:</label>
+      <input className="w-full border rounded p-2" type="text" value={data.address} onChange={e => onChange('address', e.target.value)} />
     </div>
   </fieldset>
 )

--- a/src/components/form-panels/KontakPanel.tsx
+++ b/src/components/form-panels/KontakPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { ContactForm } from './types'
+import Button from '../Button'
 
 interface Props {
   data: ContactForm
@@ -10,25 +11,25 @@ interface Props {
 }
 
 const KontakPanel: React.FC<Props> = ({ data, onChange }) => (
-  <fieldset>
-    <legend>Phone &amp; Email</legend>
-    <div>
-      <label>Country Code:</label>
-      <select value={data.countryCode} onChange={e => onChange('countryCode', e.target.value)}>
+  <fieldset className="border rounded p-4 space-y-3">
+    <legend className="font-medium">Phone &amp; Email</legend>
+    <div className="space-y-1">
+      <label className="block text-sm">Country Code:</label>
+      <select className="w-full border rounded p-2" value={data.countryCode} onChange={e => onChange('countryCode', e.target.value)}>
         <option value="">-- Select --</option>
         <option value="62">+62</option>
         <option value="1">+1</option>
       </select>
     </div>
-    <div>
-      <label>Phone Number:</label>
-      <input type="text" value={data.phoneNumber} onChange={e => onChange('phoneNumber', e.target.value)} />
+    <div className="space-y-1">
+      <label className="block text-sm">Phone Number:</label>
+      <input className="w-full border rounded p-2" type="text" value={data.phoneNumber} onChange={e => onChange('phoneNumber', e.target.value)} />
     </div>
-    <div>
-      <label>Email:</label>
-      <input type="email" value={data.email} onChange={e => onChange('email', e.target.value)} />
+    <div className="space-y-1">
+      <label className="block text-sm">Email:</label>
+      <input className="w-full border rounded p-2" type="email" value={data.email} onChange={e => onChange('email', e.target.value)} />
     </div>
-    <button type="button">Add Contact</button>
+    <Button type="button" variant="secondary">Add Contact</Button>
   </fieldset>
 )
 

--- a/src/components/form-panels/NomorIdentitasPanel.tsx
+++ b/src/components/form-panels/NomorIdentitasPanel.tsx
@@ -10,28 +10,41 @@ interface Props {
 }
 
 const NomorIdentitasPanel: React.FC<Props> = ({ data, onChange }) => (
-  <fieldset>
-    <legend>Identity Number</legend>
-    <div>
-      <label>Nationality:</label>
-      <select value={data.nationality} onChange={e => onChange('nationality', e.target.value)}>
+  <fieldset className="border rounded p-4 space-y-3">
+    <legend className="font-medium">Identity Number</legend>
+    <div className="space-y-1">
+      <label className="block text-sm">Nationality:</label>
+      <select
+        className="w-full border rounded p-2"
+        value={data.nationality}
+        onChange={e => onChange('nationality', e.target.value)}
+      >
         <option value="">-- Select --</option>
         <option value="WNI">WNI</option>
         <option value="WNA">WNA</option>
       </select>
     </div>
-    <div>
-      <label>ID Type:</label>
-      <select value={data.idType} onChange={e => onChange('idType', e.target.value)}>
+    <div className="space-y-1">
+      <label className="block text-sm">ID Type:</label>
+      <select
+        className="w-full border rounded p-2"
+        value={data.idType}
+        onChange={e => onChange('idType', e.target.value)}
+      >
         <option value="">-- Select --</option>
         <option value="KTP">KTP</option>
         <option value="SIM">SIM</option>
         <option value="Passport">Passport</option>
       </select>
     </div>
-    <div>
-      <label>ID Number:</label>
-      <input type="text" value={data.idNumber} onChange={e => onChange('idNumber', e.target.value)} />
+    <div className="space-y-1">
+      <label className="block text-sm">ID Number:</label>
+      <input
+        className="w-full border rounded p-2"
+        type="text"
+        value={data.idNumber}
+        onChange={e => onChange('idNumber', e.target.value)}
+      />
     </div>
   </fieldset>
 )

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,9 +2,10 @@ import React from 'react'
 
 const Dashboard: React.FC = () => {
   return (
-    <div>
-      <h1>Welcome to Dashboard</h1>
-    </div>
+    <section className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Welcome to Dashboard</h1>
+      <p className="text-gray-600">Select a module from the sidebar to get started.</p>
+    </section>
   )
 }
 

--- a/src/pages/admission/AdmissionLayout.tsx
+++ b/src/pages/admission/AdmissionLayout.tsx
@@ -2,9 +2,12 @@ import { Outlet } from 'react-router-dom'
 
 const AdmissionLayout: React.FC = () => {
   return (
-    <div className="admission-module">
-      <Outlet />
-    </div>
+    <section className="p-6 space-y-4">
+      <h1 className="text-xl font-semibold">Admission</h1>
+      <div className="bg-white rounded shadow p-4">
+        <Outlet />
+      </div>
+    </section>
   )
 }
 

--- a/src/pages/admission/DaftarPasien.tsx
+++ b/src/pages/admission/DaftarPasien.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom'
+import Button from '../../components/Button'
 
 interface Pasien {
   noRm: string
@@ -29,39 +30,41 @@ const DaftarPasien: React.FC = () => {
   const navigate = useNavigate()
 
   return (
-    <div>
-      <h2>Daftar Pasien</h2>
-      <button onClick={() => navigate('/admission/form-pasien-baru')}>
-        Daftarkan Pasien
-      </button>
-      <table className="pasien-table">
+    <section className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Daftar Pasien</h2>
+        <Button onClick={() => navigate('/admission/form-pasien-baru')}>
+          Daftarkan Pasien
+        </Button>
+      </div>
+      <table className="min-w-full text-sm text-left border border-gray-200">
         <thead>
           <tr>
-            <th>No RM</th>
-            <th>Nama Pasien</th>
-            <th>Tanggal Lahir</th>
-            <th>Alamat</th>
-            <th>Status</th>
-            <th>Action</th>
+            <th className="px-3 py-2 border-b">No RM</th>
+            <th className="px-3 py-2 border-b">Nama Pasien</th>
+            <th className="px-3 py-2 border-b">Tanggal Lahir</th>
+            <th className="px-3 py-2 border-b">Alamat</th>
+            <th className="px-3 py-2 border-b">Status</th>
+            <th className="px-3 py-2 border-b">Action</th>
           </tr>
         </thead>
         <tbody>
           {mockData.map((p, index) => (
             <tr key={index}>
-              <td>{p.noRm}</td>
-              <td>{p.nama}</td>
-              <td>{p.tanggalLahir}</td>
-              <td>{p.alamat}</td>
-              <td>{p.status}</td>
-              <td>
-                <button className="edit-btn">Edit</button>{' '}
-                <button className="delete-btn">Delete</button>
+              <td className="px-3 py-2 border-b">{p.noRm}</td>
+              <td className="px-3 py-2 border-b">{p.nama}</td>
+              <td className="px-3 py-2 border-b">{p.tanggalLahir}</td>
+              <td className="px-3 py-2 border-b">{p.alamat}</td>
+              <td className="px-3 py-2 border-b">{p.status}</td>
+              <td className="px-3 py-2 border-b space-x-2">
+                <Button variant="secondary" className="edit-btn">Edit</Button>
+                <Button variant="secondary" className="delete-btn">Delete</Button>
               </td>
             </tr>
           ))}
         </tbody>
       </table>
-    </div>
+    </section>
   )
 }
 

--- a/src/pages/admission/FormPasienBaru.tsx
+++ b/src/pages/admission/FormPasienBaru.tsx
@@ -7,6 +7,7 @@ import KontakPanel from '../../components/form-panels/KontakPanel'
 import KontakDaruratPanel from '../../components/form-panels/KontakDaruratPanel'
 import HubunganKeluargaPanel from '../../components/form-panels/HubunganKeluargaPanel'
 import SuccessToast from '../../components/SuccessToast'
+import Button from '../../components/Button'
 
 import type { PatientFormState, SectionKey, SimpleKey } from '../../components/form-panels/types'
 import { initialState } from '../../components/form-panels/types'
@@ -64,17 +65,18 @@ const FormPasienBaru: React.FC = () => {
 }
 
   return (
-    <div>
-      <h2>Registrasi Pasien Baru</h2>
-      <form onSubmit={handleSubmit}>
+    <section className="space-y-4">
+      <h2 className="text-lg font-semibold">Registrasi Pasien Baru</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label>
+          <label className="flex items-center space-x-2">
             <input
               type="checkbox"
+              className="form-checkbox"
               checked={form.emergency}
               onChange={(e) => handleSimpleChange('emergency', e.target.checked)}
             />
-            Register as Emergency Patient
+            <span>Register as Emergency Patient</span>
           </label>
         </div>
 
@@ -115,13 +117,11 @@ const FormPasienBaru: React.FC = () => {
           onChange={(value) => handleSimpleChange('familyPatient', value)}
         />
 
-        <div style={{ marginTop: '1rem' }}>
-          <button type="button" onClick={() => alert('Cancelled')}>
+        <div className="pt-4 flex space-x-2">
+          <Button type="button" variant="secondary" onClick={() => alert('Cancelled')}>
             Cancel
-          </button>
-          <button type="submit" style={{ marginLeft: '0.5rem' }}>
-            Save
-          </button>
+          </Button>
+          <Button type="submit">Save</Button>
         </div>
       </form>
 
@@ -131,7 +131,7 @@ const FormPasienBaru: React.FC = () => {
           onClose={() => setShowPopup(false)}
         />
       )}
-    </div>
+    </section>
   )
 }
 


### PR DESCRIPTION
## Summary
- add reusable Button component
- style dashboard
- style admission layout and patient pages
- apply Tailwind classes to form panels

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532b98bd58832b8f919b857f502903