### PR TITLE
Fix tailwind lint error

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
+/* eslint-env node */
 /** @type {import('tailwindcss').Config} */
+/* eslint-disable-next-line no-undef */
 module.exports = {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {


### PR DESCRIPTION
## Summary
- address ESLint `no-undef` error in tailwind.config.js by allowing `module`

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68539a1fa7b4832b81b7cf25301d1409