### PR TITLE
Fix role object rendering in sidebar

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -1,10 +1,15 @@
 import React, { createContext, useContext, useState, ReactNode } from 'react'
 
+interface Role {
+  id: number
+  name: string
+}
+
 interface User {
   id: number
   name: string
   email: string
-  role: string | null
+  role: Role | string | null
 }
 
 interface AuthContextType {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,14 +18,17 @@ const menuItems = [
 const Sidebar: React.FC = () => {
   const location = useLocation()
   const { user } = useAuth()
-  const [role, setRole] = useState<string>(user?.role || 'Administrator')
+  const initialRole =
+    typeof user?.role === 'string' ? user.role : user?.role?.name || 'Administrator'
+  const [role, setRole] = useState<string>(initialRole)
 
   const handleRoleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setRole(e.target.value)
   }
 
   const name = user?.name || 'Administrator'
-  const currentRole = user?.role || 'Administrator'
+  const currentRole =
+    typeof user?.role === 'string' ? user.role : user?.role?.name || 'Administrator'
 
   return (
     <aside className="sidebar bg-gray-100 p-4 w-64 space-y-4">


### PR DESCRIPTION
## Summary
- handle role objects in `AuthContext` and `Sidebar`
- derive role name correctly when backend returns `{id, name}`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68539dabe064832baff66823623ed807