### PR TITLE
Fix layout and sidebar errors

### DIFF
--- a/src/components/ProfileHeader.tsx
+++ b/src/components/ProfileHeader.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+export interface ProfileHeaderProps {
+  name: string
+  role: string
+  iconText: string
+}
+
+const ProfileHeader: React.FC<ProfileHeaderProps> = ({ name, role, iconText }) => {
+  return (
+    <div className="flex items-center p-4 bg-white rounded-lg shadow">
+      <div className="flex items-center justify-center w-12 h-12 rounded-full bg-purple-600 text-white font-bold mr-3">
+        {iconText}
+      </div>
+      <div className="flex flex-col">
+        <span className="font-bold text-sm leading-tight">{name}</span>
+        <span className="text-xs text-gray-500">{role}</span>
+      </div>
+    </div>
+  )
+}
+
+export default ProfileHeader

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useState } from 'react'
 import { useAuth } from '../auth/AuthContext'
+import ProfileHeader from './ProfileHeader'
 
 interface MenuItem {
   path?: string
@@ -37,6 +38,7 @@ const Sidebar: React.FC = () => {
 
   const name = user?.name || 'Administrator'
   const currentRole = role
+  const iconText = name.charAt(0).toUpperCase()
 
   const handleLogout = () => {
     logout()
@@ -51,19 +53,7 @@ const Sidebar: React.FC = () => {
   return (
   <aside className="h-screen w-64 bg-white shadow-lg overflow-auto p-4 space-y-4">
     {/* Profile Section */}
-    <div className="flex flex-col items-center space-y-2 p-3 rounded-lg bg-gray-50 shadow-inner">
-      <div className="w-16 h-16 rounded-full overflow-hidden border-2 border-gray-300 shadow">
-        <img
-          src={profileImage || 'public/doctor.png'}
-          alt="Profile"
-          className="w-full h-full object-cover"
-        />
-      </div>
-      <div className="text-center">
-        <p className="font-semibold text-gray-800">{name}</p>
-        <p className="text-xs text-gray-500">{currentRole}</p>
-      </div>
-    </div>
+    <ProfileHeader name={name} role={currentRole} iconText={iconText} />
 
     {/* Role Switcher */}
     <div>
@@ -116,6 +106,7 @@ const Sidebar: React.FC = () => {
       </ul>
     </nav>
   </aside>
-)
+  )
+}
 
 export default Sidebar

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -3,11 +3,7 @@ import { useAuth } from '../auth/AuthContext'
 import Sidebar from '../components/Sidebar'
 
 const MainLayout: React.FC = () => {
-  const { user, logout } = useAuth()
-
-  const handleLogout = () => {
-    logout()
-  }
+  const { user } = useAuth()
 
   return (
     <div className="dashboard flex">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import './styles/global.css'
-import App from './App.tsx'
+import App from './App'
 import { AuthProvider } from './auth/AuthContext'
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
## Summary
- clean up unused code in `MainLayout`
- fix JSX errors in `Sidebar`
- add new `ProfileHeader` component and integrate in `Sidebar`
- fix TypeScript import extension issue

## Testing
- `npm run lint`
- `npm test -- -t ''`


------
https://chatgpt.com/codex/tasks/task_e_68547b2ec530832ba83b9f60092519dc