### PR TITLE
Revamp sidebar styling

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,22 @@
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useState } from 'react'
 import { useAuth } from '../auth/AuthContext'
+
+interface MenuItem {
+  path?: string
+  label: string
+  action?: () => void
+}
+
+const menusByRole: Record<string, MenuItem[]> = {
+  Administrator: [
+    { path: '/dashboard', label: 'Dashboard' },
+    { path: '/admission', label: 'Admission' },
+    { path: '/config', label: 'Config' },
+  ],
+  Admisi: [{ path: '/admission', label: 'Admission' }],
+  Dokter: [{ path: '/dashboard', label: 'Dashboard' }],
+}
 
 const Sidebar: React.FC = () => {
   const navigate = useNavigate()
@@ -14,22 +30,29 @@ const Sidebar: React.FC = () => {
     navigate('/login', { replace: true })
   }
 
+  const menuItems: MenuItem[] = [
+    ...(menusByRole[role] ?? []),
+    { label: 'Logout', action: handleLogout },
+  ]
+
   return (
-    <aside className="bg-white shadow-lg rounded-lg p-4 w-64 h-full flex flex-col space-y-4">
-      <div className="flex flex-col items-center">
+    <aside className="bg-white shadow-lg rounded-lg p-4 w-64 h-screen flex flex-col">
+      <div className="p-3 rounded-md border border-gray-200 bg-gray-50 mb-6 flex items-center">
         <img
           src="/doctor.png"
           alt="Profile"
-          className="w-24 h-24 rounded-full border-2 border-gray-200 mb-2 object-cover"
+          className="w-12 h-12 rounded-full border border-gray-300 object-cover mr-3"
         />
-        <p className="font-semibold text-gray-700">{user?.name || 'John Doe'}</p>
-        <p className="text-sm text-gray-400">{role}</p>
+        <div>
+          <p className="text-sm font-semibold text-gray-700">{user?.name || 'John Doe'}</p>
+          <p className="text-xs text-gray-500">{role}</p>
+        </div>
       </div>
 
       <select
         value={role}
         onChange={(e) => setRole(e.target.value)}
-        className="w-full border border-gray-300 rounded-md p-2 text-sm focus:ring-2 focus:ring-blue-400 mb-4"
+        className="w-full border border-gray-300 rounded-md p-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 mb-4"
       >
         <option value="Administrator">Administrator</option>
         <option value="Admisi">Admisi</option>
@@ -37,15 +60,26 @@ const Sidebar: React.FC = () => {
       </select>
 
       <nav className="flex-1">
-        <ul>
-          <li>
-            <button
-              onClick={handleLogout}
-              className="p-2 rounded-md hover:bg-gray-100 cursor-pointer text-sm font-medium text-gray-700 transition-colors duration-200 w-full text-left"
-            >
-              Logout
-            </button>
-          </li>
+        <ul className="space-y-2">
+          {menuItems.map((item) => (
+            <li key={item.label}>
+              {item.path ? (
+                <Link
+                  to={item.path}
+                  className="block p-2 rounded-md hover:bg-gray-100 cursor-pointer text-sm font-medium text-gray-700 transition-colors duration-200"
+                >
+                  {item.label}
+                </Link>
+              ) : (
+                <button
+                  onClick={item.action}
+                  className="w-full text-left p-2 rounded-md hover:bg-gray-100 cursor-pointer text-sm font-medium text-gray-700 transition-colors duration-200"
+                >
+                  {item.label}
+                </button>
+              )}
+            </li>
+          ))}
         </ul>
       </nav>
     </aside>


### PR DESCRIPTION
## Summary
- revamp the main Sidebar component styling with Tailwind CSS
- restore dashboard and other menu items

## Testing
- `npm test --run` *(fails to exit automatically)*


------
https://chatgpt.com/codex/tasks/task_e_6854dbea702c832bbc43dcea6f758c37