### PR TITLE
Revamp sidebar and admission page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,8 +10,7 @@ import Schedule from './pages/Schedule';
 import Workforce from './pages/Workforce';
 import ProtectedRoute from './auth/ProtectedRoute';
 import MainLayout from './layout/MainLayout';
-import AdmissionLayout from './pages/admission/AdmissionLayout';
-import DaftarPasien from './pages/admission/DaftarPasien';
+import Admission from './pages/Admission';
 import FormPasienBaru from './pages/admission/FormPasienBaru';
 import Sidebar from './components/Sidebar';
 
@@ -25,11 +24,8 @@ const App: React.FC = () => (
         <Route path="dashboard" element={<Dashboard />} />
         <Route path="schedule" element={<Schedule />} />
         <Route path="workforce" element={<Workforce />} />
-        <Route path="admission" element={<AdmissionLayout />}>
-          <Route index element={<Navigate to="daftar-pasien" replace />} />
-          <Route path="daftar-pasien" element={<DaftarPasien />} />
-          <Route path="form-pasien-baru" element={<FormPasienBaru />} />
-        </Route>
+        <Route path="admission" element={<Admission />} />
+        <Route path="admission/form-pasien-baru" element={<FormPasienBaru />} />
       </Route>
     </Route>
     <Route path="*" element={<Navigate to="/login" replace />} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,14 +8,16 @@ interface MenuItem {
   action?: () => void
 }
 
-const menusByRole: Record<string, MenuItem[]> = {
+const menusByRole: Record<'Administrator' | 'Admisi', MenuItem[]> = {
   Administrator: [
     { path: '/dashboard', label: 'Dashboard' },
     { path: '/admission', label: 'Admission' },
-    { path: '/config', label: 'Config' },
+    { path: '/doctor', label: 'Doctor' },
   ],
-  Admisi: [{ path: '/admission', label: 'Admission' }],
-  Dokter: [{ path: '/dashboard', label: 'Dashboard' }],
+  Admisi: [
+    { path: '/dashboard', label: 'Dashboard' },
+    { path: '/admission', label: 'Admission' },
+  ],
 }
 
 const Sidebar: React.FC = () => {
@@ -31,17 +33,17 @@ const Sidebar: React.FC = () => {
   }
 
   const menuItems: MenuItem[] = [
-    ...(menusByRole[role] ?? []),
+    ...menusByRole[role as 'Administrator' | 'Admisi'],
     { label: 'Logout', action: handleLogout },
   ]
 
   return (
-    <aside className="bg-white shadow-lg rounded-lg p-4 w-64 h-screen flex flex-col">
+    <aside className="bg-white shadow-lg rounded-lg p-4 w-40 h-screen flex flex-col">
       <div className="p-3 rounded-md border border-gray-200 bg-gray-50 mb-6 flex items-center">
         <img
           src="/doctor.png"
           alt="Profile"
-          className="w-12 h-12 rounded-full border border-gray-300 object-cover mr-3"
+          className="w-[30px] h-[30px] rounded-md border border-gray-300 object-cover mr-3"
         />
         <div>
           <p className="text-sm font-semibold text-gray-700">{user?.name || 'John Doe'}</p>
@@ -49,24 +51,46 @@ const Sidebar: React.FC = () => {
         </div>
       </div>
 
-      <select
-        value={role}
-        onChange={(e) => setRole(e.target.value)}
-        className="w-full border border-gray-300 rounded-md p-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 mb-4"
-      >
-        <option value="Administrator">Administrator</option>
-        <option value="Admisi">Admisi</option>
-        <option value="Dokter">Dokter</option>
-      </select>
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-xs">Admisi</span>
+        <label className="relative inline-flex items-center cursor-pointer">
+          <input
+            type="checkbox"
+            className="sr-only peer"
+            checked={role === 'Administrator'}
+            onChange={() =>
+              setRole((prev) =>
+                prev === 'Administrator' ? 'Admisi' : 'Administrator'
+              )
+            }
+          />
+          <div className="w-9 h-5 bg-gray-200 rounded-full peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:left-[2px] after:top-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-4" />
+        </label>
+        <span className="text-xs">Administrator</span>
+      </div>
 
       <nav className="flex-1">
         <ul className="space-y-2">
-          <li
-            onClick={handleLogout}
-            className="p-2 rounded-md hover:bg-gray-100 cursor-pointer text-sm font-medium text-gray-700 transition-colors duration-200"
-          >
-            Logout
-          </li>
+          {menuItems.map(item => (
+            <li key={item.label} className="text-sm font-medium text-gray-700">
+              {item.path ? (
+                <Link
+                  to={item.path}
+                  className="block p-2 rounded-md hover:bg-gray-100 transition-colors"
+                >
+                  {item.label}
+                </Link>
+              ) : (
+                <button
+                  type="button"
+                  onClick={item.action}
+                  className="w-full text-left p-2 rounded-md hover:bg-gray-100"
+                >
+                  {item.label}
+                </button>
+              )}
+            </li>
+          ))}
         </ul>
       </nav>
     </aside>

--- a/src/pages/Admission.tsx
+++ b/src/pages/Admission.tsx
@@ -1,14 +1,14 @@
-import { Outlet } from 'react-router-dom'
+import DaftarPasien from './admission/DaftarPasien'
 
-const AdmissionLayout: React.FC = () => {
+const Admission: React.FC = () => {
   return (
     <section className="p-6 space-y-4">
       <h1 className="text-xl font-semibold">Admission</h1>
       <div className="bg-white rounded shadow p-4">
-        <Outlet />
+        <DaftarPasien />
       </div>
     </section>
   )
 }
 
-export default AdmissionLayout
+export default Admission


### PR DESCRIPTION
## Summary
- replace `AdmissionLayout` with new `Admission` page
- simplify router to use `Admission` and remove nested `daftar-pasien`
- redesign sidebar width and profile photo
- add role toggle and dynamic menu items

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564362b328832b88612c24625d081b