### PR TITLE
Improve sidebar profile styling

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -37,23 +37,22 @@ const Sidebar: React.FC = () => {
 
   return (
     <aside className="bg-white shadow-lg w-56 h-screen flex flex-col rounded-r-xl overflow-hidden">
-      <div className="flex items-center gap-3 p-4 bg-gray-50 border-b border-gray-200">
-        <img
-          src="/doctor.png"
-          alt="Profile"
-          className="w-[36px] h-[36px] rounded-md object-cover"
-        />
-        <div>
-          <p className="text-sm font-semibold text-gray-900">{user?.name || 'John Doe'}</p>
-          <p className="text-xs text-gray-500">{role}</p>
+      <div className="flex items-center justify-between p-4 bg-gray-50 border-b border-gray-200">
+        <div className="flex items-center gap-3">
+          <img
+            src="/doctor.png"
+            alt="Profile"
+            className="w-8 h-8 rounded-md object-cover"
+          />
+          <div className="leading-none">
+            <p className="text-sm font-medium text-gray-800">{user?.name || 'John Doe'}</p>
+            <p className="text-xs text-gray-500">{role}</p>
+          </div>
         </div>
-      </div>
-
-      <div className="p-4">
         <select
           value={role}
           onChange={(e) => setRole(e.target.value)}
-          className="mt-2 w-full border border-gray-200 rounded p-1 text-xs text-gray-600 bg-white"
+          className="border border-gray-200 rounded px-2 py-1 text-xs text-gray-600 bg-white"
         >
           <option value="Administrator">Administrator</option>
           <option value="Admisi">Admisi</option>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,31 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-html, body, #root {
+/* Base reset */
+html,
+body,
+#root {
   width: 100%;
   height: 100%;
   margin: 0;
@@ -34,46 +13,11 @@ html, body, #root {
 }
 
 body {
-  display: block; 
+  display: block;
+  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
 }
 
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}
+/* Login page */
 .login-page {
   display: flex;
   min-height: 100vh;
@@ -171,7 +115,7 @@ button:focus-visible {
   background: #0056b3;
 }
 
-/* Dashboard layout */
+/* Dashboard */
 .dashboard {
   display: flex;
   min-height: 100vh;
@@ -209,29 +153,12 @@ button:focus-visible {
 }
 
 .navbar {
-  background: #007bff;
-  color: #fff;
-  padding: 10px;
-}
-
-.content {
-  flex: 1;
-  padding: 20px;
-}
-
-@media (max-width: 768px) {
-  .dashboard {
-    flex-direction: column;
-  }
-  .sidebar {
-    width: 100%;
-  }
-}
-
-.navbar {
   display: flex;
   justify-content: flex-end;
   align-items: center;
+  background: #007bff;
+  color: #fff;
+  padding: 10px;
 }
 
 .navbar .icon {
@@ -247,3 +174,19 @@ button:focus-visible {
 .navbar .profile span {
   margin-left: 0.25rem;
 }
+
+.content {
+  flex: 1;
+  padding: 20px;
+}
+
+@media (max-width: 768px) {
+  .dashboard {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+  }
+}
+


### PR DESCRIPTION
## Summary
- clean up `global.css`
- streamline sidebar profile header with role dropdown

## Testing
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68568f189200832bb8f1a2df0a9ed5ac