### PR TITLE
Style navbar profile section via global CSS

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,5 +2,5 @@ import tailwindcss from '@tailwindcss/postcss';
 import autoprefixer from 'autoprefixer';
 
 export default {
-  plugins: [tailwindcss, autoprefixer],
+  plugins: [tailwindcss({ config: './tailwind.config.js' }), autoprefixer],
 };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -37,26 +37,35 @@ const Sidebar: React.FC = () => {
 
   return (
     <aside className="bg-white shadow-lg w-56 h-screen flex flex-col rounded-r-xl overflow-hidden">
-      <div className="flex items-center justify-between p-4 bg-gray-50 border-b border-gray-200">
-        <div className="flex items-center gap-3">
-          <img
-            src="/doctor.png"
-            alt="Profile"
-            className="w-8 h-8 rounded-md object-cover"
-          />
+      <div className="profile-container">
+        <div className="profile-info">
+          <img alt="Profile" src="/doctor.png" className="profile-img" />
           <div className="leading-none">
-            <p className="text-sm font-medium text-gray-800">{user?.name || 'John Doe'}</p>
-            <p className="text-xs text-gray-500">{role}</p>
+            <p className="profile-text-name">{user?.name || 'John Doe'}</p>
+            <p className="profile-text-role">{role}</p>
           </div>
         </div>
-        <select
-          value={role}
-          onChange={(e) => setRole(e.target.value)}
-          className="border border-gray-200 rounded px-2 py-1 text-xs text-gray-600 bg-white"
-        >
-          <option value="Administrator">Administrator</option>
-          <option value="Admisi">Admisi</option>
-        </select>
+        <div className="profile-select-wrapper">
+          <select
+            value={role}
+            onChange={(e) => setRole(e.target.value)}
+            className="profile-select"
+          >
+            <option value="Administrator">Administrator</option>
+            <option value="Admisi">Admisi</option>
+          </select>
+          <div className="profile-select-arrow">
+            <svg
+              className="profile-select-arrow-icon"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+            >
+              <path d="M19 9l-7 7-7-7" />
+            </svg>
+          </div>
+        </div>
       </div>
 
       <nav className="flex-1">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -190,3 +190,60 @@ body {
   }
 }
 
+/* Navbar profile styles */
+.profile-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2em;
+  background-color: #f9fafb; /* gray-50 */
+  border-bottom: 1px solid #e5e7eb; /* gray-200 */
+}
+.profile-info {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem; /* gap-3 */
+}
+.profile-img {
+  height: 50px;
+  width: auto;
+  border-radius: 0.375rem; /* rounded-md */
+  object-fit: cover;
+}
+.profile-text-name {
+  font-size: 0.875rem; /* text-sm */
+  font-weight: 500; /* font-medium */
+  color: #1f2937; /* gray-800 */
+}
+.profile-text-role {
+  font-size: 0.75rem; /* text-xs */
+  color: #6b7280; /* gray-500 */
+}
+.profile-select-wrapper {
+  position: relative;
+}
+.profile-select {
+  appearance: none;
+  border: 1px solid #e5e7eb; /* gray-200 */
+  border-radius: 0.375rem; /* rounded */
+  padding: 0.25rem 0.5rem; /* px-2 py-1 */
+  font-size: 0.75rem; /* text-xs */
+  color: #4b5563; /* gray-600 */
+  background-color: #ffffff;
+  padding-right: 1.5rem; /* pr-6 */
+}
+.profile-select-arrow {
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0.5rem; /* right-2 */
+  display: flex;
+  align-items: center;
+}
+.profile-select-arrow-icon {
+  width: 0.75rem;
+  height: 0.75rem;
+  color: #4b5563; /* gray-600 */
+}
+


### PR DESCRIPTION
## Summary
- add postcss config for Tailwind plugin
- rewrite profile header styles without `@apply`

## Testing
- `npm test`
- `npm run lint`
- `npm run build --silent`


------
https://chatgpt.com/codex/tasks/task_e_6856955327d4832b93963a18df546955