### PR TITLE
Fix PostCSS plugin for Tailwind CSS v4

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
-import tailwindcss from 'tailwindcss';
+import tailwindcss from '@tailwindcss/postcss';
 import autoprefixer from 'autoprefixer';
 
 export default {
-  plugins: [tailwindcss, autoprefixer],
+  plugins: [tailwindcss(), autoprefixer()],
 };


### PR DESCRIPTION
## Summary
- update PostCSS config to use `@tailwindcss/postcss`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856b30d5ae4832ba08a54ff79d96256