### PR TITLE
Use Tailwind classes in sidebar profile area

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -37,26 +37,26 @@ const Sidebar: React.FC = () => {
 
   return (
     <aside className="bg-white shadow-lg w-56 h-screen flex flex-col rounded-r-xl overflow-hidden">
-      <div className="profile-container">
-        <div className="profile-info">
-          <img alt="Profile" src="/doctor.png" className="profile-img" />
+      <div className="flex flex-col items-center gap-3 p-4 border-b">
+        <div className="flex items-center gap-3">
+          <img alt="Profile" src="/doctor.png" className="w-12 h-12 rounded-full object-cover" />
           <div className="leading-none">
-            <p className="profile-text-name">{user?.name || 'John Doe'}</p>
-            <p className="profile-text-role">{role}</p>
+            <p className="font-semibold text-sm">{user?.name || 'John Doe'}</p>
+            <p className="text-xs text-gray-500">{role}</p>
           </div>
         </div>
-        <div className="profile-select-wrapper">
+        <div className="relative w-full">
           <select
             value={role}
             onChange={(e) => setRole(e.target.value)}
-            className="profile-select"
+            className="appearance-none w-full border border-gray-300 rounded-md text-sm py-1 pl-2 pr-6 focus:outline-none"
           >
             <option value="Administrator">Administrator</option>
             <option value="Admisi">Admisi</option>
           </select>
-          <div className="profile-select-arrow">
+          <div className="pointer-events-none absolute top-1/2 right-2 -translate-y-1/2">
             <svg
-              className="profile-select-arrow-icon"
+              className="w-4 h-4 text-gray-700"
               fill="none"
               stroke="currentColor"
               strokeWidth="2"


### PR DESCRIPTION
## Summary
- replace custom `profile-*` CSS classes with Tailwind utilities in `Sidebar`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856e00a3144832b955be9900625a815