### PR TITLE
Add reusable Tailwind Button component

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,17 +1,52 @@
 import React from 'react'
 
+export const baseButtonClasses =
+  'px-4 py-2 rounded text-sm font-bold transition focus:outline-none focus:ring-2 focus:ring-blue-300'
+
+type Variant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'success'
+
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'primary' | 'secondary'
+  variant?: Variant
+  fullWidth?: boolean
+  isLoading?: boolean
 }
 
-const base = 'px-4 py-2 rounded focus:outline-none focus:ring text-sm'
-const variants = {
-  primary: `${base} bg-blue-600 text-white hover:bg-blue-700`,
-  secondary: `${base} bg-gray-200 text-gray-800 hover:bg-gray-300`,
+const variantClasses: Record<Variant, string> = {
+  primary: 'bg-blue-600 text-white hover:bg-blue-700',
+  secondary: 'bg-gray-200 text-gray-800 hover:bg-gray-300',
+  ghost: 'border border-blue-600 text-blue-600 hover:bg-blue-600 hover:text-white',
+  danger: 'bg-red-600 text-white hover:bg-red-700',
+  success: 'bg-green-600 text-white hover:bg-green-700',
 }
 
-const Button: React.FC<ButtonProps> = ({ variant = 'primary', className = '', ...props }) => (
-  <button className={`${variants[variant]} ${className}`} {...props} />
-)
+const Button: React.FC<ButtonProps> = ({
+  variant = 'primary',
+  fullWidth = false,
+  isLoading,
+  disabled,
+  className = '',
+  children,
+  ...props
+}) => {
+  const classes = [
+    baseButtonClasses,
+    variantClasses[variant],
+    fullWidth && 'w-full',
+    (disabled || isLoading) && 'opacity-50 cursor-not-allowed',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <button
+      disabled={disabled || isLoading}
+      className={classes}
+      {...props}
+    >
+      {isLoading ? 'Loading...' : children}
+    </button>
+  )
+}
 
 export default Button

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -5,6 +5,7 @@ import api from '../services/api'
 import { useAuth } from '../auth/AuthContext'
 import '../styles/global.css';
 import '../styles/login.css';
+import Button from '../components/Button';
 
 
 interface FormErrors {
@@ -87,9 +88,14 @@ const LoginPage = () => {
             <a href="#" className="forgot">Forgot your password?</a>
           </div>
 
-          <button type="submit" disabled={loading} className="login-button">
-            {loading ? 'Loading...' : 'LOGIN'}
-          </button>
+          <Button
+            type="submit"
+            className="login-button w-full"
+            disabled={loading}
+            isLoading={loading}
+          >
+            LOGIN
+          </Button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add full-featured `Button` component with multiple variants
- reuse new `Button` in `LoginPage`

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68575d1c72ec832babc7409358286d9d