### PR TITLE
Add reusable Button component

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+
+const baseButtonClasses =
+  'px-4 py-2 rounded text-sm font-bold transition focus:outline-none focus:ring-2 focus:ring-blue-300'
+
+const variantClasses = {
+  primary: 'bg-blue-600 text-white hover:bg-blue-700',
+  secondary: 'bg-gray-200 text-gray-800 hover:bg-gray-300',
+  ghost: 'border border-blue-600 text-blue-600 hover:bg-blue-600 hover:text-white',
+  danger: 'bg-red-600 text-white hover:bg-red-700',
+  success: 'bg-green-600 text-white hover:bg-green-700',
+}
+
+export type ButtonVariant = keyof typeof variantClasses
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  fullWidth?: boolean
+  isLoading?: boolean
+}
+
+const Button: React.FC<ButtonProps> = ({
+  variant = 'primary',
+  fullWidth = false,
+  disabled = false,
+  isLoading = false,
+  className = '',
+  children,
+  ...rest
+}) => {
+  const classes = [
+    baseButtonClasses,
+    variantClasses[variant],
+    fullWidth ? 'w-full' : '',
+    disabled || isLoading ? 'opacity-50 cursor-not-allowed' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <button className={classes} disabled={disabled || isLoading} {...rest}>
+      {isLoading ? 'Loading...' : children}
+    </button>
+  )
+}
+
+export default Button

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,13 +3,7 @@ import { FormEvent, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import api from '../services/api'
 import { useAuth } from '../auth/AuthContext'
-
-const baseButtonClasses =
-  'px-4 py-2 rounded focus:outline-none focus:ring text-sm font-bold transition'
-const buttonVariants = {
-  primary: `${baseButtonClasses} bg-blue-600 text-white hover:bg-blue-700`,
-  secondary: `${baseButtonClasses} bg-gray-200 text-gray-800 hover:bg-gray-300`,
-}
+import Button from '../components/Button'
 
 
 interface FormErrors {
@@ -97,13 +91,16 @@ const LoginPage = () => {
                 Forgot your password?
               </a>
             </div>
-            <button
+            <Button
               type="submit"
-              className={`${buttonVariants.primary} w-full bg-white text-blue-600 border border-blue-600 hover:bg-blue-600 hover:text-white`}
+              fullWidth
+              variant="primary"
               disabled={loading}
+              isLoading={loading}
+              className="bg-white text-blue-600 border border-blue-600 hover:bg-blue-600 hover:text-white"
             >
-              {loading ? 'Please wait...' : 'LOGIN'}
-            </button>
+              LOGIN
+            </Button>
           </form>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- build a generic `<Button>` component with variant styles and loading state
- replace LoginPage button styles with new component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68575ffe2a18832ba3b0dc58446fa267