### PR TITLE
Add ProfileCard component for sidebar

### DIFF
--- a/src/components/ProfileCard.css
+++ b/src/components/ProfileCard.css
@@ -1,0 +1,30 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer components {
+  .profile-card {
+    @apply flex items-center bg-white p-3 rounded shadow relative;
+  }
+  .profile-image {
+    @apply w-10 h-10 rounded-md object-cover;
+  }
+  .profile-name {
+    @apply font-bold text-gray-800;
+  }
+  .profile-role {
+    @apply text-sm text-gray-500;
+  }
+  .toggle-btn {
+    @apply text-gray-500 hover:text-gray-700 transition;
+  }
+  .toggle-wrapper {
+    @apply relative ml-auto w-6;
+  }
+  .role-popup {
+    @apply absolute right-0 mt-2 bg-white border rounded shadow text-sm z-10;
+  }
+  .role-item {
+    @apply block w-full text-left px-4 py-2 hover:bg-gray-100;
+  }
+}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useRef, useState } from 'react'
+import './ProfileCard.css'
+
+export interface ProfileCardProps {
+  name: string
+  role: string
+  imageUrl: string
+  onRoleSelect?: (role: string) => void
+}
+
+const dummyRoles = ['Administrator', 'Doctor', 'Nurse']
+
+const ProfileCard: React.FC<ProfileCardProps> = ({ name, role, imageUrl, onRoleSelect }) => {
+  const [open, setOpen] = useState(false)
+  const [currentRole, setCurrentRole] = useState(role)
+  const wrapperRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [])
+
+  const handleSelect = (r: string) => {
+    console.log(r)
+    setCurrentRole(r)
+    onRoleSelect && onRoleSelect(r)
+    setOpen(false)
+  }
+
+  return (
+    <div className="profile-card" ref={wrapperRef}>
+      <img src={imageUrl} alt="Profile" className="profile-image" />
+      <div className="flex flex-col flex-1 mx-3">
+        <span className="profile-name">{name}</span>
+        <span className="profile-role">{currentRole}</span>
+      </div>
+      <div className="toggle-wrapper">
+        <button
+          type="button"
+          className="toggle-btn"
+          onClick={() => setOpen(o => !o)}
+        >
+          {open ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="w-5 h-5"
+            >
+              <path
+                fillRule="evenodd"
+                d="M5.23 12.21a.75.75 0 011.06.02L10 15.584l3.71-3.354a.75.75 0 111.02 1.096l-4.22 3.807a.75.75 0 01-1.02 0l-4.22-3.807a.75.75 0 01.02-1.096z"
+                clipRule="evenodd"
+              />
+            </svg>
+          ) : (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="w-5 h-5"
+            >
+              <path
+                fillRule="evenodd"
+                d="M14.77 7.79a.75.75 0 00-1.06-.02L10 11.584 6.29 7.77a.75.75 0 10-1.02 1.096l4.22 3.807a.75.75 0 001.02 0l4.22-3.807a.75.75 0 00-.02-1.096z"
+                clipRule="evenodd"
+              />
+            </svg>
+          )}
+        </button>
+        {open && (
+          <ul className="role-popup">
+            {dummyRoles.map(r => (
+              <li key={r}>
+                <button
+                  type="button"
+                  className="role-item"
+                  onClick={() => handleSelect(r)}
+                >
+                  {r}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default ProfileCard

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate } from 'react-router-dom'
 import { useState } from 'react'
 import { useAuth } from '../auth/AuthContext'
+import ProfileCard from './ProfileCard'
 
 interface MenuItem {
   path?: string
@@ -37,35 +38,13 @@ const Sidebar: React.FC = () => {
 
   return (
     <aside className="bg-white shadow-lg w-56 h-screen flex flex-col rounded-r-xl overflow-hidden">
-      <div className="flex flex-col items-center gap-3 p-4 border-b">
-        <div className="flex items-center gap-3">
-          <img alt="Profile" src="/doctor.png" className="w-12 h-12 rounded-full object-cover" />
-          <div className="leading-none">
-            <p className="font-semibold text-sm">{user?.name || 'John Doe'}</p>
-            <p className="text-xs text-gray-500">{role}</p>
-          </div>
-        </div>
-        <div className="relative w-full">
-          <select
-            value={role}
-            onChange={(e) => setRole(e.target.value)}
-            className="appearance-none w-full border border-gray-300 rounded-md text-sm py-1 pl-2 pr-6 focus:outline-none"
-          >
-            <option value="Administrator">Administrator</option>
-            <option value="Admisi">Admisi</option>
-          </select>
-          <div className="pointer-events-none absolute top-1/2 right-2 -translate-y-1/2">
-            <svg
-              className="w-4 h-4 text-gray-700"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-            >
-              <path d="M19 9l-7 7-7-7" />
-            </svg>
-          </div>
-        </div>
+      <div>
+        <ProfileCard
+          name={user?.name || 'John Doe'}
+          role={role}
+          imageUrl="/doctor.png"
+          onRoleSelect={setRole}
+        />
       </div>
 
       <nav className="flex-1">

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "./components/button.css";
+@import "./components/ProfileCard.css";
 
 @layer base {
   html,


### PR DESCRIPTION
## Summary
- implement `ProfileCard` with role popup
- style card using Tailwind `@apply`
- use `ProfileCard` inside `Sidebar`
- register new CSS file in global styles
- adjust spacing around role toggle button

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857de1ecef8832b9dc2c4593d0f9ed1