### PR TITLE
Restore sidebar profile picture

### DIFF
--- a/src/components/ProfilePicture.tsx
+++ b/src/components/ProfilePicture.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+export interface ProfilePictureProps {
+  name: string
+  role: string
+  imageSrc: string
+}
+
+const ProfilePicture: React.FC<ProfilePictureProps> = ({ name, role, imageSrc }) => (
+  <div className="flex flex-col items-center gap-2">
+    <div className="w-16 h-16 rounded-full overflow-hidden border-2 border-gray-300 shadow">
+      <img src={imageSrc} alt="Profile" className="w-full h-full object-cover" />
+    </div>
+    <div className="text-center leading-none">
+      <p className="font-semibold text-gray-800 text-sm">{name}</p>
+      <p className="text-xs text-gray-500">{role}</p>
+    </div>
+  </div>
+)
+
+export default ProfilePicture

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate } from 'react-router-dom'
 import { useState } from 'react'
 import { useAuth } from '../auth/AuthContext'
+import ProfilePicture from './ProfilePicture'
 
 interface MenuItem {
   path?: string
@@ -38,13 +39,11 @@ const Sidebar: React.FC = () => {
   return (
     <aside className="bg-white shadow-lg w-56 h-screen flex flex-col rounded-r-xl overflow-hidden">
       <div className="flex flex-col items-center gap-3 p-4 border-b">
-        <div className="flex items-center gap-3">
-          <img alt="Profile" src="/doctor.png" className="w-12 h-12 rounded-full object-cover" />
-          <div className="leading-none">
-            <p className="font-semibold text-sm">{user?.name || 'John Doe'}</p>
-            <p className="text-xs text-gray-500">{role}</p>
-          </div>
-        </div>
+        <ProfilePicture
+          name={user?.name || 'John Doe'}
+          role={role}
+          imageSrc="/doctor.png"
+        />
         <div className="relative w-full">
           <select
             value={role}


### PR DESCRIPTION
## Summary
- add ProfilePicture component for displaying avatar, name and role
- use the new ProfilePicture in the Sidebar component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b1a7524c0832bbd8c30d1eb40367e