### PR TITLE
Refactor Sidebar and ProfileCard classes

### DIFF
--- a/src/components/ProfileCard.css
+++ b/src/components/ProfileCard.css
@@ -9,14 +9,20 @@
   .profile-image {
     @apply w-10 h-10 rounded-md object-cover;
   }
+  .profile-info {
+    @apply flex flex-col flex-1 mx-3;
+  }
   .profile-name {
     @apply font-bold text-gray-800;
   }
-  .profile-role { 
+  .profile-role {
     @apply text-sm text-gray-500;
   }
   .toggle-btn {
     @apply text-gray-500 hover:text-gray-700 transition;
+  }
+  .toggle-icon {
+    @apply w-5 h-5;
   }
   .toggle-wrapper {
     @apply relative ml-auto w-6;

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -35,7 +35,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({ name, role, imageUrl, onRoleS
   return (
     <div className="profile-card" ref={wrapperRef}>
       <img src={imageUrl} alt="Profile" className="profile-image" />
-      <div className="flex flex-col flex-1 mx-3">
+      <div className="profile-info">
         <span className="profile-name">{name}</span>
         <span className="profile-role">{currentRole}</span>
       </div>
@@ -50,7 +50,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({ name, role, imageUrl, onRoleS
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 20 20"
               fill="currentColor"
-              className="w-5 h-5"
+              className="toggle-icon"
             >
               <path
                 fillRule="evenodd"
@@ -63,7 +63,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({ name, role, imageUrl, onRoleS
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 20 20"
               fill="currentColor"
-              className="w-5 h-5"
+              className="toggle-icon"
             >
               <path
                 fillRule="evenodd"

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -3,10 +3,50 @@
 @tailwind utilities;
 
 @layer components {
+  .sidebar-container {
+    @apply bg-white shadow-lg w-56 h-screen flex flex-col rounded-r-xl overflow-hidden;
+  }
+
+  .sidebar-header {
+    @apply flex flex-col items-center gap-3 p-4 border-b;
+  }
+
+  .role-select-wrapper {
+    @apply relative w-full;
+  }
+
+  .role-select {
+    @apply appearance-none w-full border border-gray-300 rounded-md text-sm py-1 pl-2 pr-6 focus:outline-none;
+  }
+
+  .role-select-icon-wrapper {
+    @apply pointer-events-none absolute top-1/2 right-2 -translate-y-1/2;
+  }
+
+  .role-select-icon {
+    @apply w-4 h-4 text-gray-700;
+  }
+
+  .sidebar-nav {
+    @apply flex-1;
+  }
+
+  .sidebar-list {
+    @apply space-y-2;
+  }
+
   .sidebar-item {
     @apply flex items-center gap-2 px-3 py-2 rounded transition text-gray-700 hover:bg-blue-600 hover:text-white;
   }
   .sidebar-item.active {
     @apply bg-blue-600 text-white;
+  }
+
+  .sidebar-icon {
+    @apply w-4 text-center;
+  }
+
+  .sidebar-action-btn {
+    @apply w-full flex items-center justify-center p-2 text-sm text-gray-600 bg-gray-50 hover:bg-gray-100 rounded-md;
   }
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -31,25 +31,25 @@ const Sidebar: React.FC = () => {
   ]
 
   return (
-    <aside className="bg-white shadow-lg w-56 h-screen flex flex-col rounded-r-xl overflow-hidden">
-      <div className="flex flex-col items-center gap-3 p-4 border-b">
+    <aside className="sidebar-container">
+      <div className="sidebar-header">
         <ProfilePicture
           name={user?.name || 'John Doe'}
           role={role}
           imageSrc="/doctor.png"
         />
-        <div className="relative w-full">
+        <div className="role-select-wrapper">
           <select
             value={role}
             onChange={(e) => setRole(e.target.value)}
-            className="appearance-none w-full border border-gray-300 rounded-md text-sm py-1 pl-2 pr-6 focus:outline-none"
+            className="role-select"
           >
             <option value="Administrator">Administrator</option>
             <option value="Admisi">Admisi</option>
           </select>
-          <div className="pointer-events-none absolute top-1/2 right-2 -translate-y-1/2">
+          <div className="role-select-icon-wrapper">
             <svg
-              className="w-4 h-4 text-gray-700"
+              className="role-select-icon"
               fill="none"
               stroke="currentColor"
               strokeWidth="2"
@@ -61,26 +61,29 @@ const Sidebar: React.FC = () => {
         </div>
       </div>
 
-      <nav className="flex-1">
-        <ul className="space-y-2">
+      <nav className="sidebar-nav">
+        <ul className="sidebar-list">
           {menuItems.map(item => (
             <li key={item.label}>
               {item.path ? (
                 <Link
                   to={item.path}
                   onClick={() => setActive(item.label)}
-                  className={`flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors ${
-                    active === item.label ? 'bg-gray-200 text-gray-900' : 'text-gray-700 hover:bg-gray-100'
-                  }`}
+                  className={[
+                    'sidebar-item',
+                    active === item.label && 'active',
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
                 >
-                  {item.icon && <i className={`${item.icon} w-4 text-center`}></i>}
+                  {item.icon && <i className={`${item.icon} sidebar-icon`}></i>}
                   {item.label}
                 </Link>
               ) : (
                 <button
                   type="button"
                   onClick={item.action}
-                  className="w-full flex items-center justify-center p-2 text-sm text-gray-600 bg-gray-50 hover:bg-gray-100 rounded-md"
+                  className="sidebar-action-btn"
                 >
                   {item.label}
                 </button>


### PR DESCRIPTION
## Summary
- remove inline styles from Sidebar and ProfileCard
- add utility classes in related CSS
- use those classes in components

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b334fcdac832b9287801b47616e48